### PR TITLE
Adjusting timestamp calculation based on window time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ import (
 )
 
 func main() {
-	totp := totp.StdTOTP
-	totp.K, _ = base32.StdEncoding.DecodeString("BASE32SECRET")
+	totp_inst := totp.StdTOTP
+	totp_inst.K, _ = base32.StdEncoding.DecodeString("BASE32SECRET")
 
-	if totp.Validate(123456) {
+	if _, ok := totp_inst.Validate(123456); ok {
 		// Valid token
 	} else {
-		// Invalid token
+		// Not a valid token
 	}
 }
 

--- a/totp.go
+++ b/totp.go
@@ -30,7 +30,7 @@ func (t *TOTP) Validate(code uint64) (map[uint64]uint64, bool) {
 
     try_num := -(t.WindowSize-1)/2 + count
 
-    timestamp := time.Now().Unix() + int64(try_num)
+    timestamp := time.Now().Unix() + (int64(t.Window)*int64(try_num))
 
 	//Verify reuse case based on stored timestamps.
 	// clock := uint64(time.Now().Unix() / t.Window)

--- a/totp.go
+++ b/totp.go
@@ -12,7 +12,7 @@ import (
 type TOTP struct {
 	K      []byte
 	Digit  int
-	Window int64
+	Window uint64
 	WindowSize int
 
 }
@@ -34,7 +34,7 @@ func (t *TOTP) Validate(code uint64) (map[uint64]uint64, bool) {
 
 	//Verify reuse case based on stored timestamps.
 	// clock := uint64(time.Now().Unix() / t.Window)
-	clock := uint64(timestamp / t.Window)
+	clock := uint64(timestamp) / t.Window
 	C := make([]byte, 8)
 	binary.BigEndian.PutUint64(C, clock)
 


### PR DESCRIPTION
- Multiplying the try factor by the token validation window. It will scroll the timestamp up and down.
- Changing usage example to be compatible with new version.